### PR TITLE
Add Random Bookmark From Folder, if acceptable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 
 ## Open Source
 - [Sapper HackerNews Clone](https://github.com/sveltejs/hn.svelte.dev#readme) - A Hacker News clone built with Svelte and Sapper.
+- [Random Bookmark From Folder](https://github.com/PikadudeNo1/RandomBookmark) - A Firefox/Chrome extension for opening random bookmarks.
 
 ## Apps/Websites
 


### PR DESCRIPTION
I'd like to add [Random Bookmark From Folder](https://github.com/PikadudeNo1/RandomBookmark), an open-source browser extension to the list. I'm not 100% sure it meets the standards set out in this project's CONTRIBUTING.md, though:

- Screenshots are presently external to the repo, on the extension store pages.
- Info for contributing is currently limited to how to run the build process, and is part of the README rather than a dedicated CONTRIBUTING file.

If any of the above are blockers, let me know.